### PR TITLE
Suggestions for Numo support

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -106,14 +106,14 @@ Now we can run the inference.
 
 ```ruby
 # execute inference
-inferenced_results = model.run image_set
+inference_results = model.run image_set
 ```
 
-The `inferenced_results` is the array that contains the hash of results of `output_layers`. So you can get each value as follows.
+The `inference_results` is the array that contains the hash of results of `output_layers`. So you can get each value as follows.
 
 ```ruby
-fc6_out = inferenced_results.find { |x| x[:name] == FC6_OUT_NAME }
-softmax_out = inferenced_results.find { |x| x[:name] == SOFTMAX_OUT_NAME }
+fc6_out = inference_results.find { |x| x[:name] == FC6_OUT_NAME }
+softmax_out = inference_results.find { |x| x[:name] == SOFTMAX_OUT_NAME }
 ```
 
 That's it.

--- a/example/example_mnist.rb
+++ b/example/example_mnist.rb
@@ -58,11 +58,11 @@ image_set = [
   }
 ]
 # execute inference
-inferenced_results = model.run image_set
+inference_results = model.run image_set
 
 categories = (0..9).to_a
 TOP_K = 1
-layer_result = inferenced_results.find { |x| x[:name] == MNIST_OUT_NAME }
+layer_result = inference_results.find { |x| x[:name] == MNIST_OUT_NAME }
 layer_result[:data].zip(image_list).each do |image_result, image_filepath|
   # sort by score
   sorted_result = image_result.zip(categories).sort_by { |x| -x[0] }

--- a/example/example_mnist_with_block.rb
+++ b/example/example_mnist_with_block.rb
@@ -57,10 +57,10 @@ Menoh::Menoh.new './data/mnist.onnx' do |onnx_obj|
       }
     ]
     # execute inference
-    model.run image_set do |inferenced_results|
+    model.run image_set do |inference_results|
       categories = (0..9).to_a
       TOP_K = 1
-      layer_result = inferenced_results.find { |x| x[:name] == MNIST_OUT_NAME }
+      layer_result = inference_results.find { |x| x[:name] == MNIST_OUT_NAME }
       layer_result[:data].zip(image_list).each do |image_result, image_filepath|
         # sort by score
         sorted_result = image_result.zip(categories).sort_by { |x| -x[0] }

--- a/example/example_vgg16.rb
+++ b/example/example_vgg16.rb
@@ -78,12 +78,12 @@ image_set = [
 ]
 
 # execute inference
-inferenced_results = model.run image_set
+inference_results = model.run image_set
 
 # load category definition
 categories = File.read('./data/synset_words.txt').split("\n")
 TOP_K = 5
-layer_result = inferenced_results.find { |x| x[:name] == SOFTMAX_OUT_NAME }
+layer_result = inference_results.find { |x| x[:name] == SOFTMAX_OUT_NAME }
 layer_result[:data].zip(image_list).each do |image_result, image_filepath|
   puts "=== Result for #{image_filepath} ==="
 

--- a/test/menoh_test.rb
+++ b/test/menoh_test.rb
@@ -32,10 +32,10 @@ class MenohTest < Minitest::Test
           data: (0..(batch_size - 1)).map { |_i| (0..(1 * 28 * 28 - 1)).to_a }.flatten
         }
       ]
-      inferenced_results = model.run imageset
-      assert_instance_of(Array, inferenced_results)
-      assert_equal(MNIST_OUT_NAME, inferenced_results.first[:name])
-      assert_equal(batch_size, inferenced_results.first[:data].length)
+      inference_results = model.run imageset
+      assert_instance_of(Array, inference_results)
+      assert_equal(MNIST_OUT_NAME, inference_results.first[:name])
+      assert_equal(batch_size, inference_results.first[:data].length)
     end
   end
 
@@ -61,10 +61,10 @@ class MenohTest < Minitest::Test
       assert_instance_of(Menoh::Menoh, onnx)
       onnx.make_model(model_opt) do |model|
         assert_instance_of(Menoh::MenohModel, model)
-        model.run(imageset) do |inferenced_results|
-          assert_instance_of(Array, inferenced_results)
-          assert_equal(MNIST_OUT_NAME, inferenced_results.first[:name])
-          assert_equal(batch_size, inferenced_results.first[:data].length)
+        model.run(imageset) do |inference_results|
+          assert_instance_of(Array, inference_results)
+          assert_equal(MNIST_OUT_NAME, inference_results.first[:name])
+          assert_equal(batch_size, inference_results.first[:data].length)
         end
       end
     end

--- a/test/menoh_test.rb
+++ b/test/menoh_test.rb
@@ -47,11 +47,11 @@ class MenohTest < Minitest::Test
           data: (0..(batch_size - 1)).map { |_i| (0..(1 * 28 * 28 - 1)).to_a }.flatten
         }
       ]
-      inferenced_results = model.run(imageset, numo_narray: true)
-      assert_instance_of(Array, inferenced_results)
-      assert_equal(MNIST_OUT_NAME, inferenced_results.first[:name])
-      assert_instance_of(Numo::SFloat, inferenced_results.first[:data])
-      assert_equal([batch_size, 10], inferenced_results.first[:data].shape)
+      inference_results = model.run(imageset, numo_narray: true)
+      assert_instance_of(Array, inference_results)
+      assert_equal(MNIST_OUT_NAME, inference_results.first[:name])
+      assert_instance_of(Numo::SFloat, inference_results.first[:data])
+      assert_equal([batch_size, 10], inference_results.first[:data].shape)
     end
     # input: Numo::SFloat, output: Numo::SFloat
     10.times do
@@ -61,11 +61,11 @@ class MenohTest < Minitest::Test
           data: Numo::SFloat.zeros(batch_size, 1, 28, 28)
         }
       ]
-      inferenced_results = model.run(imageset, numo_narray: true)
-      assert_instance_of(Array, inferenced_results)
-      assert_equal(MNIST_OUT_NAME, inferenced_results.first[:name])
-      assert_instance_of(Numo::SFloat, inferenced_results.first[:data])
-      assert_equal([batch_size, 10], inferenced_results.first[:data].shape)
+      inference_results = model.run(imageset, numo_narray: true)
+      assert_instance_of(Array, inference_results)
+      assert_equal(MNIST_OUT_NAME, inference_results.first[:name])
+      assert_instance_of(Numo::SFloat, inference_results.first[:data])
+      assert_equal([batch_size, 10], inference_results.first[:data].shape)
     end
     # input: Numo::SFloat, output: Array
     10.times do
@@ -75,10 +75,10 @@ class MenohTest < Minitest::Test
           data: Numo::SFloat.zeros(batch_size, 1, 28, 28)
         }
       ]
-      inferenced_results = model.run(imageset)
-      assert_instance_of(Array, inferenced_results)
-      assert_equal(MNIST_OUT_NAME, inferenced_results.first[:name])
-      assert_equal(batch_size, inferenced_results.first[:data].length)
+      inference_results = model.run(imageset)
+      assert_instance_of(Array, inference_results)
+      assert_equal(MNIST_OUT_NAME, inference_results.first[:name])
+      assert_equal(batch_size, inference_results.first[:data].length)
     end
   end
 


### PR DESCRIPTION
This PR is related to https://github.com/pfnet-research/menoh-ruby/pull/27.
I have some suggestions before merging your work.

 1. integrate method `run` and `run_numo`
     - please see commits for detail
 2. integrate data types of the inference result
     - currently I choosed `Array` of `Hash`es
     - each layer names are embedded as `:name`

How is your opinion?
Thank you.